### PR TITLE
Fix main runtime usage error

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,15 @@
 import streamlit as st
+from streamlit.runtime.scriptrunner_utils.script_run_context import (
+    get_script_run_ctx,
+)
+
+# Exit with a helpful message if run directly without `streamlit run`
+if get_script_run_ctx(suppress_warning=True) is None:
+    raise RuntimeError("Please run this app using 'streamlit run main.py'")
+
 # Set page layout to wide
 st.set_page_config(layout="wide")
+
 # ---- PAGE SETUP ----
 
 about_page = st.Page(
@@ -22,8 +31,8 @@ tablecolumnmapping_page = st.Page(
 
 pg = st.navigation(
     {
-    "Info": [about_page],
-    "Config Tables": [dataloadparameter_page, tablecolumnmapping_page]
+        "Info": [about_page],
+        "Config Tables": [dataloadparameter_page, tablecolumnmapping_page],
     }
 )
 


### PR DESCRIPTION
## Summary
- prevent running main.py directly by checking Streamlit runtime context
- remove stray text at EOF and fix indentation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `streamlit run main.py --server.headless true --browser.gatherUsageStats false` (startup log checked)


------
https://chatgpt.com/codex/tasks/task_e_683f4fd8a9948327a44fed2f37f94c20