### PR TITLE
Fix create_config_table docstring

### DIFF
--- a/tableutils.py
+++ b/tableutils.py
@@ -10,8 +10,7 @@ def create_config_table(data_file, page_title):
     rows, renaming, and deleting columns/rows.
 
     Args:
-        data_file (str): Path to the JSON file to save/load data.
-        table_name (str): Name of the table to display.
+        data_file (str): Path to the JSON file used to save or load the table.
         page_title (str): Title for the Streamlit page.
     """
     # Page Title


### PR DESCRIPTION
## Summary
- remove stale `table_name` parameter
- update `data_file` parameter text

## Testing
- `python -m py_compile tableutils.py main.py pages/*.py`


------
https://chatgpt.com/codex/tasks/task_e_683f513082d4832783cf489e0e99b266