### PR TITLE
Fix login redirect to default page

### DIFF
--- a/pages/login.py
+++ b/pages/login.py
@@ -24,6 +24,6 @@ if st.button("Login"):
         customers = get_customers(username)
         if customers:
             st.session_state["selected_customer"] = customers[0]
-        st.switch_page("")  # Go to default page
+        st.switch_page("about")  # Go to default page
     else:
         st.error("Invalid username or password")


### PR DESCRIPTION
## Summary
- direct user to the About page after login instead of empty page path

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f622dd4d08327b9eae4d6ddcf2ab7