### PR TITLE
Fix login redirect attribute

### DIFF
--- a/main.py
+++ b/main.py
@@ -36,7 +36,7 @@ pg = st.navigation([
 # ---- PAGE SETUP ----
 
 if "authenticated" not in st.session_state or not st.session_state["authenticated"]:
-    if pg.page != login_page:
+    if pg.url_path != login_page.url_path:
         st.switch_page("login")
     else:
         pg.run()


### PR DESCRIPTION
## Summary
- fix `main.py` to use `url_path` instead of nonexistent `page` attribute

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f63156b248327a84aedb939d66b35