### PR TITLE
Fix login redirect to about page

### DIFF
--- a/pages/login.py
+++ b/pages/login.py
@@ -24,6 +24,8 @@ if st.button("Login"):
         customers = get_customers(username)
         if customers:
             st.session_state["selected_customer"] = customers[0]
-        st.switch_page("about")  # Go to default page
+        # Navigate to the default page after successful login
+        # Use the page path relative to the main script
+        st.switch_page("pages/about.py")
     else:
         st.error("Invalid username or password")


### PR DESCRIPTION
## Summary
- fix wrong path in login redirect

## Testing
- `PYTHONPATH=$(pwd) pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f652f67a8832798ef4ce4ef4e8722